### PR TITLE
changes defocus to defocus

### DIFF
--- a/tmaven/interface/viewer_molecules.py
+++ b/tmaven/interface/viewer_molecules.py
@@ -249,7 +249,6 @@ class molecules_widget(QTableView):
 				for i in sel:
 					self.gui.maven.data.classes[i] = new_class_ind
 			self.model.dataChanged.emit(QModelIndex(),QModelIndex())
-			return
 		# elif event.key() == Qt.Key_Tab:
 		# 	sel = self.get_selection()
 		# 	if not sel is None:
@@ -258,10 +257,20 @@ class molecules_widget(QTableView):
 		# 	self.model.dataChanged.emit(QModelIndex(),QModelIndex())
 		elif event == QKeySequence.Undo:
 			self.undo()
+			self.defocus()
 		elif event == QKeySequence.Redo:
 			self.redo()
+			self.defocus()
+		elif event.key() == Qt.Key_Escape:
+			self.defocus()
 		else:
 			super().keyPressEvent(event)
+
+	def defocus(self):
+		try:
+			self.parent().parent().setFocus()
+		except:
+			pass
 
 	def undo(self):
 		if len(self.undo) > 0:

--- a/tmaven/interface/viewer_prefs.py
+++ b/tmaven/interface/viewer_prefs.py
@@ -153,7 +153,6 @@ class pref_model(QAbstractTableModel):
 
 		return Qt.NoItemFlags
 
-
 class prefs_widget(QWidget):
 	''' QWidget that displays a `prefs_object`
 
@@ -237,11 +236,16 @@ class prefs_widget(QWidget):
 		'''
 		if event.key() == Qt.Key_Escape:
 			if self.le_filter.hasFocus() and not str(self.le_filter.text()) == "":
-				self.le_filter.clear()
-				return
-			self.le_filter.setFocus()
-			self.proxy_view.clearSelection()
-			super().keyPressEvent(event)
+				self.refocus_le()
+			else:
+				try:
+					self.parent().parent().setFocus()
+				except:
+					pass
+			return
+			# self.le_filter.setFocus()
+			# self.proxy_view.clearSelection()
+			# super().keyPressEvent(event)
 
 		elif event.key() == Qt.Key_Return and self.le_filter.hasFocus():
 			# clicksign = 'Execute'
@@ -255,3 +259,5 @@ class prefs_widget(QWidget):
 				self.focusNextChild()
 				self.proxy_view.setCurrentIndex(self.proxy_model.index(0,1))
 				return
+		else:
+			super().keyPressEvent(event)


### PR DESCRIPTION
@KorakRay @MayaBodick , here are my fixes focus the defocus issue for the dock widgets (preference and molecule table). The escape key plays a big role in 'exiting' each dock now. Also, after you make a change to a table option, you are often now 'kicked out' of editing further. Please let me know if you think there are other ways you rather go about this interaction.

We should also consider any other big changes here.